### PR TITLE
#248: Invert container name.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ docker image:
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_DRIVER: overlay2
+    DOCKER_BUILDKIT: 1
   services:
     - docker:dind
   before_script:
@@ -28,7 +29,7 @@ docker image:
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     - docker pull $CI_REGISTRY_IMAGE:latest || true
-    - docker build --cache-from $CI_REGISTRY_IMAGE:latest --tag $CI_REGISTRY_IMAGE:$VERSION --tag $CI_REGISTRY_IMAGE:latest .
+    - docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $CI_REGISTRY_IMAGE:latest --tag $CI_REGISTRY_IMAGE:$VERSION --tag $CI_REGISTRY_IMAGE:latest .
     - docker push $CI_REGISTRY_IMAGE:$VERSION
     - docker push $CI_REGISTRY_IMAGE:latest
     - docker logout $CI_REGISTRY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.61.1
+* [#248: Invert container name.](https://github.com/haensl/haensl.github.io.src/issues/248)
+* Use `npm ci` command for container.
+
 ### 2.61.0
 * [#245: Remove stack.](https://github.com/haensl/haensl.github.io.src/issues/245)
 * Replace publications & talks with resources.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 2.61.1
 * [#248: Invert container name.](https://github.com/haensl/haensl.github.io.src/issues/248)
 * Use `npm ci` command for container.
+* Use buildkit when building Docker image.
 
 ### 2.61.0
 * [#245: Remove stack.](https://github.com/haensl/haensl.github.io.src/issues/245)

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:lts-alpine
 COPY --chown=node:node dist/hpdietz.com/ /var/www/
 USER node
 WORKDIR /var/www
-RUN npm i --production
+ENV NODE_ENV=production
+RUN npm ci
 ENTRYPOINT ["npm"]
 CMD ["start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   haensl.github.io:
     build: .
     image: registry.gitlab.com/hpd/haensl.github.io.src:$VERSION
-    container_name: 'haensl.github.io'
+    container_name: 'io.github.haensl'
     networks:
       - io.github.haensl
     restart: unless-stopped


### PR DESCRIPTION
### 2.61.1
* [#248: Invert container name.](https://github.com/haensl/haensl.github.io.src/issues/248)
* Use `npm ci` command for container.
