### PR TITLE
#250: Remove obsolete pull when building Docker image.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,6 @@ docker image:
     - export CI_REGISTRY_AUTH_TOKEN=$(echo -n "gitlab-ci-token:${CI_JOB_TOKEN}" | base64)
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-    - docker pull $CI_REGISTRY_IMAGE:latest || true
     - docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $CI_REGISTRY_IMAGE:latest --tag $CI_REGISTRY_IMAGE:$VERSION --tag $CI_REGISTRY_IMAGE:latest .
     - docker push $CI_REGISTRY_IMAGE:$VERSION
     - docker push $CI_REGISTRY_IMAGE:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 2.61.2
+* [#250: Remove obsolete pull when building Docker image.](https://github.com/haensl/haensl.github.io.src/issues/250)
+
 ### 2.61.1
 * [#248: Invert container name.](https://github.com/haensl/haensl.github.io.src/issues/248)
 * Use `npm ci` command for container.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haensl.github.io",
-  "version": "2.61.0",
+  "version": "2.61.2",
   "description": "The github.io page of HP Dietz.",
   "main": "dist/hpdietz.com/app.js",
   "engines": {


### PR DESCRIPTION
### 2.61.2
* [#250: Remove obsolete pull when building Docker image.](https://github.com/haensl/haensl.github.io.src/issues/250)
