### PR TITLE
#258: Fix german Docker image.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ docker image de:
     - export CI_REGISTRY_AUTH_TOKEN=$(echo -n "gitlab-ci-token:${CI_JOB_TOKEN}" | base64)
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-    - docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $CI_REGISTRY_IMAGE:latest --tag $CI_REGISTRY_IMAGE:$VERSION-de --tag $CI_REGISTRY_IMAGE:latest-de .
+    - docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from $CI_REGISTRY_IMAGE:latest -f Dockerfile.de --tag $CI_REGISTRY_IMAGE:$VERSION-de --tag $CI_REGISTRY_IMAGE:latest-de .
     - docker push $CI_REGISTRY_IMAGE:$VERSION-de
     - docker push $CI_REGISTRY_IMAGE:latest-de
     - docker logout $CI_REGISTRY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.0.1
+* [#258: Fix german Docker image.](https://github.com/haensl/haensl.github.io.src/issues/258)
+
 ### 3.0.0
 * Localize application:
   * Add new domain: https://hpdietz.de for german visitors.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haensl.github.io",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "The github.io page of HP Dietz.",
   "domains": [
     {


### PR DESCRIPTION
### 3.0.1
* [#258: Fix german Docker image.](https://github.com/haensl/haensl.github.io.src/issues/258)

Closes #258 