### PR TITLE
#257: Bump ini from 1.3.5 to 1.3.8 via dependabot.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.0.3
+* [#257: Bump ini from 1.3.5 to 1.3.8 via dependabot.](https://github.com/haensl/haensl.github.io.src/pull/257)
+
 ### 3.0.2
 * [#260: Fix mobile UI.](https://github.com/haensl/haensl.github.io.src/issues/260)
 * Update dependencies.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "haensl.github.io",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haensl.github.io",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "The github.io page of HP Dietz.",
   "domains": [
     {


### PR DESCRIPTION
### 3.0.3
* [#257: Bump ini from 1.3.5 to 1.3.8 via dependabot.](https://github.com/haensl/haensl.github.io.src/pull/257)
