### PR TITLE
#280: Fix page title.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.0.15
+* [#280: Fix page title.](https://github.com/haensl/haensl.github.io.src/issues/280)
+
 ### 3.0.14
 * [#280: Fix page title.](https://github.com/haensl/haensl.github.io.src/issues/280)
 * Update dependencies.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haensl.github.io",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "The github.io page of HP Dietz.",
   "domains": [
     {

--- a/src/templates/index/template.mustache
+++ b/src/templates/index/template.mustache
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://{{domain}}" />
     <meta property="og:description" name="description" content="{{description}}" />
 
-    <title>{{me.name}} | {{name_unescaped}}</title>
+    <title>{{me.name}} | {{nameUnescaped}}</title>
 
     <link rel="canonical" href="https://{{domain}}">
     <link rel="shortcut icon" href="https://{{domain}}/assets/img/avatar_2x.png">


### PR DESCRIPTION
### 3.0.15
* [#280: Fix page title.](https://github.com/haensl/haensl.github.io.src/issues/280)

Closes #280 